### PR TITLE
RequestParameter: add parameter location validation and its default value

### DIFF
--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -2,6 +2,7 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Apitte\Core\Schema\EndpointParameter;
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
@@ -40,7 +41,7 @@ final class RequestParameter
 	public function __construct(
 		string $name,
 		string $type,
-		string $in,
+		string $in = EndpointParameter::IN_PATH,
 		bool $required = true,
 		bool $allowEmpty = false,
 		bool $deprecated = false,
@@ -53,6 +54,10 @@ final class RequestParameter
 
 		if ($type === '') {
 			throw new AnnotationException('Empty @RequestParameter type given');
+		}
+
+		if (!in_array($in, EndpointParameter::IN, true)) {
+			throw new AnnotationException('Invalid @RequestParameter in given');
 		}
 
 		$this->name = $name;

--- a/tests/cases/Annotation/Controller/RequestParameter.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameter.phpt
@@ -24,9 +24,28 @@ test(function (): void {
 	);
 
 	Assert::same('Parameter', $requestParameter->getName());
-	Assert::same('Desc', $requestParameter->getDescription());
 	Assert::same(EndpointParameter::TYPE_STRING, $requestParameter->getType());
 	Assert::same(EndpointParameter::IN_QUERY, $requestParameter->getIn());
+	Assert::true($requestParameter->isRequired());
+	Assert::false($requestParameter->isAllowEmpty());
+	Assert::false($requestParameter->isDeprecated());
+	Assert::same('Desc', $requestParameter->getDescription());
+});
+
+// OK - short
+test(function (): void {
+	$requestParameter = new RequestParameter(
+		'Parameter',
+		EndpointParameter::TYPE_STRING
+	);
+
+	Assert::same('Parameter', $requestParameter->getName());
+	Assert::same(EndpointParameter::TYPE_STRING, $requestParameter->getType());
+	Assert::same(EndpointParameter::IN_PATH, $requestParameter->getIn());
+	Assert::true($requestParameter->isRequired());
+	Assert::false($requestParameter->isAllowEmpty());
+	Assert::false($requestParameter->isDeprecated());
+	Assert::null($requestParameter->getDescription());
 });
 
 // Exception - no type
@@ -34,4 +53,11 @@ test(function (): void {
 	Assert::exception(function (): void {
 		new RequestParameter('Param', '', EndpointParameter::IN_PATH);
 	}, AnnotationException::class, 'Empty @RequestParameter type given');
+});
+
+// Exception - invalid parameter location
+test(function (): void {
+	Assert::exception(function (): void {
+		new RequestParameter('Param', EndpointParameter::TYPE_STRING, 'invalid');
+	}, AnnotationException::class, 'Invalid @RequestParameter in given');
 });

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../../../bootstrap.php';
 
 use Apitte\Core\DI\Loader\DoctrineAnnotationLoader;
 use Apitte\Core\Schema\Builder\Controller\Controller;
+use Apitte\Core\Schema\EndpointParameter;
 use Apitte\Core\Schema\SchemaBuilder;
 use Nette\DI\ContainerBuilder;
 use Tester\Assert;
@@ -62,14 +63,14 @@ function testRequestParameters(Controller $controller): void
 
 	Assert::equal('name_value', $firstParameter->getName());
 	Assert::equal('type_value', $firstParameter->getType());
-	Assert::equal('in_value', $firstParameter->getIn());
+	Assert::equal(EndpointParameter::IN_PATH, $firstParameter->getIn());
 	Assert::null($firstParameter->getDescription());
 
 	$secondParameter = $requestParametersMethod->getParameters()['name_value_2'];
 
 	Assert::equal('name_value_2', $secondParameter->getName());
 	Assert::equal('type_value_2', $secondParameter->getType());
-	Assert::equal('in_value_2', $secondParameter->getIn());
+	Assert::equal(EndpointParameter::IN_QUERY, $secondParameter->getIn());
 	Assert::null($secondParameter->getDescription());
 }
 

--- a/tests/fixtures/Controllers/AnnotationMultiController.php
+++ b/tests/fixtures/Controllers/AnnotationMultiController.php
@@ -29,8 +29,8 @@ final class AnnotationMultiController extends ApiV1Controller
 
 	/**
 	 * @RequestParameters({
-	 *		@RequestParameter(name="name_value", type="type_value", in="in_value"),
-	 *		@RequestParameter(in="in_value_2", type="type_value_2", name="name_value_2")
+	 *		@RequestParameter(name="name_value", type="type_value", in="path"),
+	 *		@RequestParameter(in="query", type="type_value_2", name="name_value_2")
 	 * })
 	 */
 	public function requestParameters(): void

--- a/tests/fixtures/Controllers/AttributeMultiController.php
+++ b/tests/fixtures/Controllers/AttributeMultiController.php
@@ -18,8 +18,8 @@ final class AttributeMultiController extends ApiV1Controller
 	{
 	}
 
-	#[RequestParameter(name: 'name_value', type: 'type_value', in: 'in_value')]
-	#[RequestParameter(in: 'in_value_2', type: 'type_value_2', name: 'name_value_2')]
+	#[RequestParameter(name: 'name_value', type: 'type_value', in: 'path')]
+	#[RequestParameter(in: 'query', type: 'type_value_2', name: 'name_value_2')]
 	public function requestParameters(): void
 	{
 	}


### PR DESCRIPTION
Fixes BC break - until version 0.8.0, the `in` parameter had the default value of `path`. See https://github.com/contributte/apitte-core/blob/v0.7.1/src/Annotation/Controller/RequestParameter.php#L66.