### PR TITLE
Allowed params in GroupPath

### DIFF
--- a/src/Schema/Validation/GroupPathValidation.php
+++ b/src/Schema/Validation/GroupPathValidation.php
@@ -57,8 +57,8 @@ class GroupPathValidation implements IValidation
 				// -> a-z
 				// -> A-Z
 				// -> 0-9
-				// -> -_/
-				$match = Regex::match($path, '#([^a-zA-Z0-9\-_/]+)#');
+				// -> -_/{}
+				$match = Regex::match($path, '#([^a-zA-Z0-9\-_/{}]+)#');
 
 				if ($match !== null) {
 					throw new InvalidSchemaException(
@@ -70,6 +70,34 @@ class GroupPathValidation implements IValidation
 						)
 					);
 				}
+
+				// Allowed parameter characters:
+				// -> a-z
+				// -> A-Z
+				// -> 0-9
+				// -> -_
+				// @regex https://regex101.com/r/APckUJ/3
+				$matches = Regex::matchAll($path, '#\{(.+)\}#U');
+				if ($matches !== null) {
+					foreach ($matches as $item) {
+						$match = Regex::match($item[1], '#.*([^a-zA-Z0-9\-_]+).*#');
+
+						if ($match !== null) {
+							throw (new InvalidSchemaException(
+								sprintf(
+									'@Path "%s" in "%s::%s()" contains illegal characters "%s" in parameter. Allowed characters in parameter are only {[a-z-A-Z0-9-_]+}',
+									$path,
+									$controller->getClass(),
+									$method->getName(),
+									$match[1]
+								)
+							))
+								->withController($controller)
+								->withMethod($method);
+						}
+					}
+				}
+
 			}
 		}
 	}

--- a/src/Schema/Validation/GroupPathValidation.php
+++ b/src/Schema/Validation/GroupPathValidation.php
@@ -63,7 +63,7 @@ class GroupPathValidation implements IValidation
 				if ($match !== null) {
 					throw new InvalidSchemaException(
 						sprintf(
-							'@Path "%s" in "%s" contains illegal characters "%s". Allowed characters are only [a-zA-Z0-9-_/].',
+							'@Path "%s" in "%s" contains illegal characters "%s". Allowed characters are only [a-zA-Z0-9-_/{}].',
 							$path,
 							$controller->getClass(),
 							$match[1]
@@ -85,19 +85,16 @@ class GroupPathValidation implements IValidation
 						if ($match !== null) {
 							throw (new InvalidSchemaException(
 								sprintf(
-									'@Path "%s" in "%s::%s()" contains illegal characters "%s" in parameter. Allowed characters in parameter are only {[a-z-A-Z0-9-_]+}',
+									'@Path "%s" in "%s" contains illegal characters "%s" in parameter. Allowed characters in parameter are only {[a-z-A-Z0-9-_]+}',
 									$path,
 									$controller->getClass(),
-									$method->getName(),
 									$match[1]
 								)
 							))
-								->withController($controller)
-								->withMethod($method);
+								->withController($controller);
 						}
 					}
 				}
-
 			}
 		}
 	}

--- a/tests/cases/Schema/Validation/GroupPathValidation.phpt
+++ b/tests/cases/Schema/Validation/GroupPathValidation.phpt
@@ -24,6 +24,19 @@ test(function (): void {
 	});
 });
 
+// Validate: success with parameter
+test(function (): void {
+	$validation = new GroupPathValidation();
+	$builder = new SchemaBuilder();
+
+	$c1 = $builder->addController('c1');
+	$c1->addGroupPath('/foo/{bar}');
+
+	Assert::noError(function () use ($validation, $builder): void {
+		$validation->validate($builder);
+	});
+});
+
 // Validate: only /
 test(function (): void {
 	$validation = new GroupPathValidation();
@@ -69,9 +82,22 @@ test(function (): void {
 	$builder = new SchemaBuilder();
 
 	$c1 = $builder->addController('c1');
-	$c1->addGroupPath('/{foo$}');
+	$c1->addGroupPath('/foo$');
 
 	Assert::exception(function () use ($validation, $builder): void {
 		$validation->validate($builder);
-	}, InvalidSchemaException::class, '@Path "/{foo$}" in "c1" contains illegal characters "{". Allowed characters are only [a-zA-Z0-9-_/].');
+	}, InvalidSchemaException::class, '@Path "/foo$" in "c1" contains illegal characters "$". Allowed characters are only [a-zA-Z0-9-_/{}].');
+});
+
+// Validate: invalid parameter (contains)
+test(function (): void {
+	$validation = new GroupPathValidation();
+	$builder = new SchemaBuilder();
+
+	$c1 = $builder->addController('c1');
+	$c1->addGroupPath('/{foo&&&bar}');
+
+	Assert::exception(function () use ($validation, $builder): void {
+		$validation->validate($builder);
+	}, InvalidSchemaException::class, '@Path "/{foo&&&bar}" in "c1" contains illegal characters "&&&". Allowed characters are only [a-zA-Z0-9-_/{}].');
 });


### PR DESCRIPTION
This PR allows to add parameters to GroupPath. 
Parameter has to be defined as usual in method and it is available by usual methods.

Examples of base Controller:
```
#[Path('/organizations/{oid}')]
abstract class BaseOrganizationsController extends BaseController
{ }
```

Example of Controller with method:
```
#[Path('/projects')]
class GetOneProjectController extends BaseOrganizationsController
{
	#[Path('/{pid}')]
	#[Method('GET')]
	#[RequestParameter(name: 'oid', type: 'string', in: 'path')]
	#[RequestParameter(name: 'pid', type: 'string', in: 'path')]
	public function getByPid(ApiRequest $request, ApiResponse $response): ApiResponse
	{
		$pid = (string) $request->getParameter('pid');
		$oid = (string) $request->getParameter('oid');

		...

		return $response;
	}
}
```