### PR TITLE
Added getSchemaType for apitte/openapi schema change

### DIFF
--- a/src/Schema/EndpointParameter.php
+++ b/src/Schema/EndpointParameter.php
@@ -68,6 +68,15 @@ final class EndpointParameter
 		return $this->type;
 	}
 
+    public function getSchemaType(): string
+    {
+        return match($this->type) {
+            EndpointParameter::TYPE_INTEGER => 'integer',
+            EndpointParameter::TYPE_BOOLEAN => 'boolean',
+            default => $this->type
+        };
+    }
+
 	public function getDescription(): ?string
 	{
 		return $this->description;


### PR DESCRIPTION
Hello, 

just found some errors in swagger json validators.
This PR has dependency into my second PR in apitte/openapi.

![image](https://user-images.githubusercontent.com/7610662/179979362-48ff179a-9d9d-45c5-a6fc-ee469a259b1c.png)

I added method for "schemaType" in EndpointParametr. This method i use in apitte/openapi - CoreDefinition (method createParameter).

This PR changes only the datatypes of int => integer and bool => boolean in export to json specifications.

Second PR in appitte/openapi -> https://github.com/contributte/apitte-openapi/pull/48